### PR TITLE
Add subtitle to the title pape

### DIFF
--- a/beamerinnerthemematerial.sty
+++ b/beamerinnerthemematerial.sty
@@ -24,6 +24,7 @@
                       fuzzy shadow={0mm}{ 0.2mm}{0mm}{0.2mm}{shadow!20!primary}, % topBig
                       width=\paperwidth, height=0.6\paperheight, flushright upper, valign=bottom, boxsep=0.5cm]
       {\usebeamerfont{title} \inserttitle}\\
+      {\usebeamerfont{subtitle} \insertsubtitle}\\
       % {\usebeamerfont{author}\insertauthor}\\
       % {\usebeamerfont{author}\insertdate}
     \end{tcolorbox}


### PR DESCRIPTION
I've added a line of code **{\usebeamerfont{subtitle} \insertsubtitle}** under the line https://github.com/tuna/thulib-latex-talk/blob/master/beamerinnerthemematerial.sty#L26.
After that users of this latex template could use command **\subtitle{}** in https://github.com/tuna/thulib-latex-talk/blob/master/latex-talk.tex to add a subtitle below the main title in title page.